### PR TITLE
Remove `tiktoken python` dependency and replace with simple word tokenizer logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,39 +16,28 @@ add_subdirectory(src)
 find_package(CURL REQUIRED)
 find_package(inja REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
-find_package(
-  Python3
-  COMPONENTS Development
-  REQUIRED)
 
 # Build the DuckDB static and loadable extensions
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
 
 # Link libraries for the static extension
-target_link_libraries(
-  ${EXTENSION_NAME} CURL::libcurl nlohmann_json::nlohmann_json pantor::inja
-  ${Python3_LIBRARIES})
+target_link_libraries(${EXTENSION_NAME} CURL::libcurl
+                      nlohmann_json::nlohmann_json pantor::inja)
 
 # Link libraries for the loadable extension
-target_link_libraries(
-  ${LOADABLE_EXTENSION_NAME} CURL::libcurl nlohmann_json::nlohmann_json
-  pantor::inja ${Python3_LIBRARIES})
+target_link_libraries(${LOADABLE_EXTENSION_NAME} CURL::libcurl
+                      nlohmann_json::nlohmann_json pantor::inja)
 
-# Include Python headers in both static and loadable extensions
-target_include_directories(${EXTENSION_NAME} PRIVATE ${Python3_INCLUDE_DIRS})
-target_include_directories(${LOADABLE_EXTENSION_NAME}
-                           PRIVATE ${Python3_INCLUDE_DIRS})
-
-file(
-  COPY "${CMAKE_CURRENT_SOURCE_DIR}/src/core/functions/scalar/get_num_tokens.py"
-  DESTINATION "${CMAKE_BINARY_DIR}/extension/${TARGET_NAME}")
-
-file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/src/templates/lf_map/prompt_template.txt"
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/src/templates/lf_map_prompt_template.txt"
      DESTINATION "${CMAKE_BINARY_DIR}/extension/${TARGET_NAME}")
 
 file(
-  COPY "${CMAKE_CURRENT_SOURCE_DIR}/src/templates/lf_generate/lf_generate_prompt_template.txt"
+  COPY "${CMAKE_CURRENT_SOURCE_DIR}/src/templates/lf_generate_prompt_template.txt"
+  DESTINATION "${CMAKE_BINARY_DIR}/extension/${TARGET_NAME}")
+
+file(
+  COPY "${CMAKE_CURRENT_SOURCE_DIR}/src/templates/lf_filter_prompt_template.txt"
   DESTINATION "${CMAKE_BINARY_DIR}/extension/${TARGET_NAME}")
 
 # Install the extension

--- a/src/core/functions/scalar/get_num_tokens.py
+++ b/src/core/functions/scalar/get_num_tokens.py
@@ -1,8 +1,0 @@
-# GetNumTokens.py
-
-import tiktoken
-
-def num_tokens(text):
-    encoding = tiktoken.get_encoding("cl100k_base")
-    tokens = encoding.encode(text)
-    return len(tokens)

--- a/src/core/functions/scalar/lf_filter.cpp
+++ b/src/core/functions/scalar/lf_filter.cpp
@@ -75,7 +75,6 @@ std::string combine_values2(const nlohmann::json &json_obj) {
 inline std::vector<std::string> ConstructPrompts2(std::vector<nlohmann::json> &unique_rows, Connection &con,
                                                   std::string prompt_name, int model_max_tokens = 4096) {
     inja::Environment env;
-    Tiktoken::SetupPython();
 
     auto query_result = con.Query(
         "SELECT prompt FROM lf_config.LARGE_FLOCK_PROMPT_INTERNAL_TABLE WHERE prompt_name = '" + prompt_name + "'");

--- a/src/core/functions/scalar/lf_generate.cpp
+++ b/src/core/functions/scalar/lf_generate.cpp
@@ -75,7 +75,6 @@ std::string combine_values3(const nlohmann::json &json_obj) {
 inline std::vector<std::string> ConstructPrompts3(std::vector<nlohmann::json> &unique_rows, Connection &con,
                                                   std::string prompt_name, int model_max_tokens = 4096) {
     inja::Environment env;
-    Tiktoken::SetupPython();
 
     auto query_result = con.Query(
         "SELECT prompt FROM lf_config.LARGE_FLOCK_PROMPT_INTERNAL_TABLE WHERE prompt_name = '" + prompt_name + "'");

--- a/src/core/functions/scalar/lf_map.cpp
+++ b/src/core/functions/scalar/lf_map.cpp
@@ -75,7 +75,6 @@ std::string combine_values(const nlohmann::json &json_obj) {
 inline std::vector<std::string> ConstructPrompts(std::vector<nlohmann::json> &unique_rows, Connection &con,
                                                  std::string prompt_name, int model_max_tokens = 4096) {
     inja::Environment env;
-    Tiktoken::SetupPython();
 
     auto query_result = con.Query(
         "SELECT prompt FROM lf_config.LARGE_FLOCK_PROMPT_INTERNAL_TABLE WHERE prompt_name = '" + prompt_name + "'");
@@ -102,7 +101,7 @@ inline std::vector<std::string> ConstructPrompts(std::vector<nlohmann::json> &un
         }
         exe_path[len] = '\0'; // Null-terminate the path
         auto template_path =
-            std::filesystem::path(exe_path).remove_filename() / "extension/large_flock/prompt_template.txt";
+            std::filesystem::path(exe_path).remove_filename() / "extension/large_flock/lf_map_prompt_template.txt";
 
         auto template_tokens = Tiktoken::GetNumTokens(PromptFileToString(template_path.c_str()));
         auto max_tokens_for_rows = model_max_tokens - template_tokens;

--- a/src/core/model_manager/model_manager.cpp
+++ b/src/core/model_manager/model_manager.cpp
@@ -29,7 +29,7 @@ nlohmann::json ModelManager::CallComplete(const std::string &prompt, const std::
     }
 
     // check if settings is not empty and has max_tokens and temperature else make some default values
-    auto max_tokens = 100;
+    auto max_tokens = 4000;
     auto temperature = 0.5;
     if (!settings.empty()) {
         for (auto &[key, value] : settings.items()) {
@@ -44,12 +44,10 @@ nlohmann::json ModelManager::CallComplete(const std::string &prompt, const std::
     }
 
     // Create a JSON request payload with the provided parameters
-    nlohmann::json request_payload = {
-        {"model", model},
-        {"messages", {{{"role", "user"}, {"content", prompt}}}},
-        {"max_tokens", max_tokens},
-        {"temperature", temperature}
-    };
+    nlohmann::json request_payload = {{"model", model},
+                                      {"messages", {{{"role", "user"}, {"content", prompt}}}},
+                                      {"max_tokens", max_tokens},
+                                      {"temperature", temperature}};
 
     // Conditionally add "response_format" if json_response is true
     if (json_response) {
@@ -92,7 +90,8 @@ nlohmann::json ModelManager::CallComplete(const std::string &prompt, const std::
 
 nlohmann::json ModelManager::CallEmbedding(const std::string &input, const std::string &model) {
     // List of supported models
-    static const std::unordered_set<std::string> supported_models = {"text-embedding-3-small", "text-embedding-3-large"};
+    static const std::unordered_set<std::string> supported_models = {"text-embedding-3-small",
+                                                                     "text-embedding-3-large"};
 
     // Check if the provided model is in the list of supported models
     if (supported_models.find(model) == supported_models.end()) {

--- a/src/core/model_manager/tiktoken.cpp
+++ b/src/core/model_manager/tiktoken.cpp
@@ -1,30 +1,16 @@
 #include <filesystem>
 #include <large_flock/core/model_manager/tiktoken.hpp>
+#include <regex>
 
 namespace large_flock {
 
 namespace core {
 
 int Tiktoken::GetNumTokens(const std::string &str) {
-
-    int length = 0;
-    std::string word;
-    for (char c : str) {
-        if (c == ' ') {
-            if (!word.empty()) {
-                length++;
-                word.clear();
-            }
-        } else {
-            word += c;
-        }
-    }
-
-    if (!word.empty()) {
-        length++;
-    }
-
-    return length;
+    std::regex word_regex(R"(\w+|[^\w\s])");
+    auto words_begin = std::sregex_iterator(str.begin(), str.end(), word_regex);
+    auto words_end = std::sregex_iterator();
+    return std::distance(words_begin, words_end);
 }
 
 } // namespace core

--- a/src/core/model_manager/tiktoken.cpp
+++ b/src/core/model_manager/tiktoken.cpp
@@ -1,4 +1,3 @@
-#include <Python.h>
 #include <filesystem>
 #include <large_flock/core/model_manager/tiktoken.hpp>
 
@@ -6,72 +5,24 @@ namespace large_flock {
 
 namespace core {
 
-void Tiktoken::SetupPython() {
-    // Initialize the Python interpreter
-    Py_Initialize();
-
-    // Determine the path to the Python script directory
-    char exe_path[4096];
-    ssize_t len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
-    if (len == -1) {
-        throw std::runtime_error("Failed to determine the executable path.");
-    }
-    exe_path[len] = '\0'; // Null-terminate the path
-    auto script_dir = std::filesystem::path(exe_path).remove_filename() / "extension/large_flock";
-
-    // Add the Python script directory to sys.path
-    auto *sys_path = PySys_GetObject("path");
-    if (!sys_path) {
-        throw std::runtime_error("Failed to get Python sys.path.");
-    }
-    auto *folder_path = PyUnicode_FromString(script_dir.string().c_str());
-    if (!folder_path) {
-        throw std::runtime_error("Failed to create Python string for the folder path.");
-    }
-    if (PyList_Append(sys_path, folder_path) != 0) {
-        throw std::runtime_error("Failed to append folder path to Python sys.path.");
-    }
-    Py_DECREF(folder_path);
-}
-
 int Tiktoken::GetNumTokens(const std::string &str) {
-    // Import the Python module
-    auto *module_name = PyUnicode_FromString("get_num_tokens");
-    if (!module_name) {
-        throw std::runtime_error("Failed to create Python string for the module name.");
-    }
-    auto *module = PyImport_Import(module_name);
-    Py_DECREF(module_name);
-    if (!module) {
-        PyErr_Print();
-        throw std::runtime_error("Failed to import Python module 'get_num_tokens'.");
+
+    int length = 0;
+    std::string word;
+    for (char c : str) {
+        if (c == ' ') {
+            if (!word.empty()) {
+                length++;
+                word.clear();
+            }
+        } else {
+            word += c;
+        }
     }
 
-    // Get the Python function from the module
-    auto *func = PyObject_GetAttrString(module, "num_tokens");
-    Py_DECREF(module);
-    if (!func || !PyCallable_Check(func)) {
-        PyErr_Print();
-        throw std::runtime_error("Cannot find or call the Python function 'num_tokens'.");
+    if (!word.empty()) {
+        length++;
     }
-
-    auto *python_input = PyUnicode_FromString(str.c_str());
-    if (!python_input) {
-        throw std::runtime_error("Failed to create Python string for input.");
-    }
-
-    // Call the Python function
-    auto *result = PyObject_CallOneArg(func, python_input);
-    Py_DECREF(func);
-    Py_DECREF(python_input);
-    if (!result) {
-        PyErr_Print();
-        throw std::runtime_error("Failed to call Python function 'num_tokens'.");
-    }
-
-    // Extract the integer result from the Python object
-    int length = static_cast<int>(PyLong_AsLong(result));
-    Py_DECREF(result);
 
     return length;
 }

--- a/src/include/large_flock/core/model_manager/tiktoken.hpp
+++ b/src/include/large_flock/core/model_manager/tiktoken.hpp
@@ -8,7 +8,6 @@ namespace core {
 
 class Tiktoken {
 public:
-    static void SetupPython();
     static int GetNumTokens(const std::string &str);
 };
 

--- a/src/templates/lf_filter_prompt_template.txt
+++ b/src/templates/lf_filter_prompt_template.txt
@@ -16,8 +16,6 @@ Respond in a json format as follow:
 
 {
     "rows":[
-        {
-            // Your response here in json format where you specify the column name and the value associated
-        }
+        // For each row in the input rows check the prompt condition if it's valid. The answers should be in boolean format separated by commas for each row.
     ]
 }

--- a/src/templates/lf_generate_prompt_template.txt
+++ b/src/templates/lf_generate_prompt_template.txt
@@ -16,6 +16,6 @@ Respond in a json format as follow:
 
 {
     "rows":[
-        // Your response here in plain text for each row
+        // For each row in the input rows answer the prompt in a plain text format.
     ]
 }

--- a/src/templates/lf_map_prompt_template.txt
+++ b/src/templates/lf_map_prompt_template.txt
@@ -16,6 +16,6 @@ Respond in a json format as follow:
 
 {
     "rows":[
-        // Your response here should be a boolean values seprated by commas that show if the condition at each row is met or not (TRUE/FALSE)
+        // For each row in the input rows add the necessary columns that would ensure that the prompt is correctly answered.
     ]
 }


### PR DESCRIPTION
This PR removes the tiktoken Python dependency and replaces it with a basic word tokenization logic. The goal is to simplify the setup for users by eliminating the need to install Python-specific packages like tiktoken. We will eventually address the need for advanced tokenization by completing the development of the tiktoken C++ library, which will offer better performance and flexibility without requiring Python setup.